### PR TITLE
Add unit tests for load_all_words function

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -173,6 +173,16 @@ mod tests {
     }
 
     #[test]
+    fn test_load_all_words_empty() {
+        let uri = "file:///test".parse::<Uri>().unwrap();
+        let mut docs = HashMap::new();
+        docs.insert(uri.clone(), "".to_string());
+
+        let words = load_all_words(uri, &docs).unwrap();
+        assert!(words.is_empty());
+    }
+
+    #[test]
     fn test_create_completion_response() {
         let uri = "file:///test".parse::<Uri>().unwrap();
         let mut docs = HashMap::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,6 +183,19 @@ mod tests {
     }
 
     #[test]
+    fn test_load_all_words_special_chars() {
+        let uri = "file:///test".parse::<Uri>().unwrap();
+        let mut docs = HashMap::new();
+        docs.insert(uri.clone(), "let x1 = 42; // @#$%".to_string());
+
+        let words = load_all_words(uri, &docs).unwrap();
+        let expected_words: HashSet<String> =
+            ["let", "x1"].iter().cloned().map(String::from).collect();
+
+        assert_eq!(words, expected_words);
+    }
+
+    #[test]
     fn test_create_completion_response() {
         let uri = "file:///test".parse::<Uri>().unwrap();
         let mut docs = HashMap::new();


### PR DESCRIPTION
Introduce unit tests to verify the behavior of the load_all_words function with empty input and special characters. These tests ensure the function handles edge cases correctly.